### PR TITLE
Round memory down for SPAdes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### `Added`
+
+### `Fixed`
+
+- [#88](https://github.com/bacterial-genomics/wf-paired-end-illumina-assembly/pull/88) Resolved issue where SPAdes fails when a non-integer is used with the memory parameter (@gregorysprenger).
+
+### `Updated`
+
+### `Deprecated`
+
 ## v2.3.0 - March 20, 2024
 
 ### `Added`

--- a/modules/local/assemble_contigs_skesa/main.nf
+++ b/modules/local/assemble_contigs_skesa/main.nf
@@ -15,7 +15,7 @@ process ASSEMBLE_CONTIGS_SKESA {
 
     shell:
     allow_snps = params.skesa_allow_snps ? "--allow snps" : ""
-    memory = Math.round(Math.floor(task.memory.toString().replaceAll("[GB]", "").toFloat()))
+    memory     = Math.round(Math.floor(task.memory.toString().replaceAll("[GB]", "").toFloat()))
     '''
     source bash_functions.sh
 

--- a/modules/local/assemble_contigs_spades/main.nf
+++ b/modules/local/assemble_contigs_spades/main.nf
@@ -15,14 +15,14 @@ process ASSEMBLE_CONTIGS_SPADES {
     path("versions.yml")                                                       , emit: versions
 
     shell:
-    mode_list = ["--isolate", "--sc", "--meta", "--plasmid", "--rna", "--metaviral", "--metaplasmid", "--corona"]
-    mode = (params.spades_mode !in mode_list) ? "" : params.spades_mode
+    mode_list  = ["--isolate", "--sc", "--meta", "--plasmid", "--rna", "--metaviral", "--metaplasmid", "--corona"]
+    mode       = (params.spades_mode !in mode_list) ? "" : params.spades_mode
+    memory     = Math.round(Math.floor(task.memory.toString().replaceAll("[GB]", "").toFloat()))
     '''
     source bash_functions.sh
 
     # Run SPAdes assembler; try up to 3 times
     msg "INFO: Assembling contigs using SPAdes"
-    RAMSIZE=$(echo !{task.memory} | cut -d ' ' -f 1)
 
     spades.py \
       -1 "!{meta.id}_R1.paired.fq.gz" \
@@ -31,7 +31,7 @@ process ASSEMBLE_CONTIGS_SPADES {
       -o SPAdes \
       -k !{params.spades_kmer_sizes} \
       !{mode} \
-      --memory "${RAMSIZE}" \
+      --memory !{memory} \
       --threads !{task.cpus}
 
     # Verify file output


### PR DESCRIPTION
<!--
# wf-paired-end-illumina-assembly pull request

Many thanks for contributing to wf-paired-end-illumina-assembly workflow!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/bacterial-genomics/wf-paired-end-illumina-assembly/blob/main/.github/CONTRIBUTING.md)
-->

This PR fixes #87 and will round the allocated memory down to the nearest whole number.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bacterial-genomics/wf-paired-end-illumina-assembly/blob/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <outdir>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
