### PR TITLE
Bug fixes and updated container

### DIFF
--- a/modules/local/align_16S_blast/main.nf
+++ b/modules/local/align_16S_blast/main.nf
@@ -5,7 +5,7 @@ process ALIGN_16S_BLAST {
 
     input:
     tuple val(meta), path(barnapp_extracted_rna)
-    tuple val(meta2), path(database)
+    tuple val(db_name), path(database)
 
     output:
     tuple val(meta), path("${meta.id}-${meta.assembler}.16S_BLASTn_Output_File.tsv"), emit: qc_filecheck
@@ -19,7 +19,7 @@ process ALIGN_16S_BLAST {
 
     msg "INFO: Performing BLASTn alignments"
 
-    export BLASTDB=!{database}
+    export BLASTDB="${database}"
 
     blastn \
       -word_size 10 \

--- a/modules/local/align_16S_blast/main.nf
+++ b/modules/local/align_16S_blast/main.nf
@@ -5,7 +5,7 @@ process ALIGN_16S_BLAST {
 
     input:
     tuple val(meta), path(barnapp_extracted_rna)
-    tuple val(db_name), path("database/*")
+    tuple val(meta2), path(database)
 
     output:
     tuple val(meta), path("${meta.id}-${meta.assembler}.16S_BLASTn_Output_File.tsv"), emit: qc_filecheck
@@ -19,12 +19,12 @@ process ALIGN_16S_BLAST {
 
     msg "INFO: Performing BLASTn alignments"
 
-    export BLASTDB=database
+    export BLASTDB=!{database}
 
     blastn \
       -word_size 10 \
       -task blastn \
-      -db "!{db_name}" \
+      -db "!{meta2}" \
       -num_threads "!{task.cpus}" \
       -query "!{barnapp_extracted_rna}" \
       -out "!{meta.id}-!{meta.assembler}.blast.tsv" \

--- a/modules/local/remove_host_hostile/main.nf
+++ b/modules/local/remove_host_hostile/main.nf
@@ -2,7 +2,7 @@ process REMOVE_HOST_HOSTILE {
 
     label "process_high"
     tag { "${meta.id}" }
-    container "https://depot.galaxyproject.org/singularity/hostile%3A2.0.2--pyhdfd78af_0"
+    container "quay.io/biocontainers/hostile@sha256:6bd59d49795a567cffc3cf47366e5c4bc494dc4eabb216efa7637d1690572f09"
 
     input:
     tuple val(meta), path(reads)
@@ -56,7 +56,7 @@ process REMOVE_HOST_HOSTILE {
         clean \
         --fastq1 "${reads[0]}" \
         --fastq2 "${reads[1]}" \
-        --out-dir hostile \
+        --output hostile \
         --force \
         "\${HOST_INDEX_ARGUMENT}" \
         --threads ${task.cpus}
@@ -65,7 +65,7 @@ process REMOVE_HOST_HOSTILE {
         clean \
         --fastq1 "${reads[0]}" \
         --fastq2 "${reads[1]}" \
-        --out-dir hostile \
+        --output hostile \
         --force \
         --threads ${task.cpus}
     fi

--- a/modules/local/remove_host_hostile/main.nf
+++ b/modules/local/remove_host_hostile/main.nf
@@ -2,7 +2,7 @@ process REMOVE_HOST_HOSTILE {
 
     label "process_high"
     tag { "${meta.id}" }
-    container "quay.io/biocontainers/hostile:0.2.0--pyhdfd78af_0"
+    container "https://depot.galaxyproject.org/singularity/hostile%3A2.0.2--pyhdfd78af_0"
 
     input:
     tuple val(meta), path(reads)
@@ -56,7 +56,7 @@ process REMOVE_HOST_HOSTILE {
         clean \
         --fastq1 "!{reads[0]}" \
         --fastq2 "!{reads[1]}" \
-        --out-dir hostile \
+        --output hostile \
         --force \
         "${HOST_INDEX_ARGUMENT}" \
         --threads !{task.cpus}
@@ -65,7 +65,7 @@ process REMOVE_HOST_HOSTILE {
         clean \
         --fastq1 "!{reads[0]}" \
         --fastq2 "!{reads[1]}" \
-        --out-dir hostile \
+        --output hostile \
         --force \
         --threads !{task.cpus}
     fi

--- a/modules/local/subsample_reads_to_depth_seqkit/main.nf
+++ b/modules/local/subsample_reads_to_depth_seqkit/main.nf
@@ -33,6 +33,7 @@ process SUBSAMPLE_READS_TO_DEPTH_SEQKIT {
     if [[ ${fraction_of_reads_to_use} -ge 1 ]]; then
       msg "INFO: Subsample fraction is 1.0 (100%) or more. Skipping downsampling routine."
       touch "!{meta.id}.Subsampled_FastQ.SHA512-checksums.tsv" versions.yml
+      echo 'false' > downsampled.flag
       exit 0
     fi
     if [ ${depth%.*} -gt 0 ] && [ ${initial_depth%.*} -gt ${depth%.*} ]; then

--- a/workflows/assembly.nf
+++ b/workflows/assembly.nf
@@ -233,7 +233,6 @@ def toLower(it) {
 def qcfilecheck(process, qcfile, inputfile) {
     qcfile.map{ meta, file -> [ meta, [file] ] }
             .join(inputfile)
-            .collect()
             .map{ meta, qc, input ->
                 data = []
                 qc.flatten().each{ data += it.readLines() }

--- a/workflows/assembly.nf
+++ b/workflows/assembly.nf
@@ -991,18 +991,21 @@ workflow ASSEMBLY {
             ch_db_for_blast = BLAST_DB_PREPARATION_UNIX.out.db.collect()
 
         } else if ( ch_blast_db_file.isDirectory() ) {
-            ch_db_for_blast = Channel
-                                    .fromPath( "${ch_blast_db_file}/{16S_ribosomal_RNA.n*,taxdb.b*}" )
-                                    .collect()
-                                    .map{
-                                        file ->
-                                            if (file.size() >= 3) {
-                                                [ file[0].getSimpleName(), file ]
-                                            } else {
-                                                error("16S_ribosomal_RNA BLAST database requires at least '16S_ribosomal_RNA.{nin,nsq,nhr}' files.")
-                                            }
-                                    }
-                                    .collect()
+            // ch_db_for_blast = Channel
+            //                         .fromPath( "${ch_blast_db_file}/{16S_ribosomal_RNA.n*,taxdb.b*}" )
+            //                         .collect()
+            //                         .map{
+            //                             file ->
+            //                                 if (file.size() >= 3) {
+            //                                     file
+            //                                 } else {
+            //                                     error("16S_ribosomal_RNA BLAST database requires at least '16S_ribosomal_RNA.{nin,nsq,nhr}' files.")
+            //                                 }
+            //                         }
+            //                         .collect()
+            ch_db_for_blast = ["16S_ribosomal_RNA","${params.blast_db}"]
+
+            //ch_db_for_blast = [ "16S_ribosomal_RNA", ch_db_for_blast ]
 
         } else {
             error("Unsupported object given to --blast_db, database must be supplied as either a directory or a .tar.gz file!")


### PR DESCRIPTION
<!--
# wf-paired-end-illumina-assembly pull request

Many thanks for contributing to wf-paired-end-illumina-assembly workflow!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/bacterial-genomics/wf-paired-end-illumina-assembly/blob/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).  
1. Removed .collect() from qcfile channel since this caused the channel to be in the wrong format for downstream analysis
2. Replaced hostile container with newer version container (0.2.0->2.0.2) since 0.2.0 would fail on certain samples
3. swapped hostile --out-dir flag for --output since this flag changed between 0.2.0 and 2.0.2
4. Added missing `echo 'false' > downsampled.flag` from if statement in [subsample_reads_to_depth](https://github.com/bacterial-genomics/wf-paired-end-illumina-assembly/blob/main/modules/local/subsample_reads_to_depth_seqkit/main.nf) since in cases where that if statement is true, samples will not be downsampled
5. Altered how the 16S BLAST database is passed to the [align_16S_blast](https://github.com/bacterial-genomics/wf-paired-end-illumina-assembly/blob/main/modules/local/align_16S_blast/main.nf) module since the previous implementation will randomly return "taxdb" or "16S_ribosomal_RNA" as the name of the database. The align_16S_blast process will error out if "taxdb" is passed as the name.
6. Made changes to the align_16S_blast module to account for changes in the database channel passed to it
- [ ] If you've fixed a bug or added code that should be tested, add tests!  
I tested with non-publicly available test data to find bugs in these edge cases.
I tested using the following command:
```
nextflow \
  -log "${OUT}/pipeline_info/nextflow_log.${time_stamp}.txt" \
  run \
  "${LAB_HOME}/fork/wf-paired-end-illumina-assembly/main.nf" \
  -profile scicomp_rosalind,singularity \
  --input "${IN}" \
  --outdir "${OUT}" \
  -ansi-log false \
  -N "${USER}@cdc.gov" \
  -with-dag "${OUT}/pipeline_info/dag.${time_stamp}.html" \
  --blast_db "${LAB_HOME}/.databases/ncbi" \
  --checkm2_db "${LAB_HOME}/.databases/checkm2" \
  --kraken2_db "${LAB_HOME}/.databases/kraken2" \
  --sra_scrubber_db "${LAB_HOME}/.databases/sra-human-scrubber/data/human_filter.db" \
  --create_excel_outputs \
  -c "scicomp_new.config" \
  -resume
```
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bacterial-genomics/wf-paired-end-illumina-assembly/blob/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).  
It is unclear what version of nf-core was used for the development of this pipeline. It does not lint with `nf-core pipelines lint` with version 3.5.1
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <outdir>`).   
 Used singularity profile instead of docker
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
